### PR TITLE
Fixed hyperlink for clustermap.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ comparison figures.
 Given a set of GenBank files, clinker will automatically extract protein translations,
 perform global alignments between sequences in each cluster, determine the
 optimal display order based on cluster similarity, and generate an interactive
-visualisation (using ![clustermap.js](https://github.com/gamcil/clustermap.js))
+visualisation (using [clustermap.js](https://github.com/gamcil/clustermap.js))
 that can be extensively tweaked before being exported as an SVG file.
 
 ## Installation


### PR DESCRIPTION
removed "!" at beginning of clustermap.js link, was showing a broken image in the rendered MD.