### PR TITLE
Add --no_align argument

### DIFF
--- a/clinker/align.py
+++ b/clinker/align.py
@@ -367,6 +367,8 @@ class Globaligner:
         """
         if len(self.clusters) == 1:
             return [0]
+        if not self.alignments:
+            return list(range(len(self.clusters)))
         matrix = self.matrix(i=i, normalise=True, as_distance=True)
         linkage = hierarchy.linkage(squareform(matrix), method=method)
         return hierarchy.leaves_list(linkage)[::-1]

--- a/clinker/main.py
+++ b/clinker/main.py
@@ -32,6 +32,7 @@ def clinker(
     plot=None,
     output=None,
     force=False,
+    no_align=False,
     hide_link_headers=False,
     hide_alignment_headers=False,
 ):
@@ -49,7 +50,10 @@ def clinker(
     clusters = parse_files(paths)
 
     # Align all clusters
-    if len(clusters) == 1:
+    if no_align:
+        globaligner = align.Globaligner()
+        globaligner.add_clusters(*clusters)
+    elif len(clusters) == 1:
         globaligner = align.align_clusters(clusters[0])
     else:
         LOG.info("Starting cluster alignments")
@@ -100,6 +104,12 @@ def get_parser():
 
     alignment = parser.add_argument_group("Alignment options")
     alignment.add_argument(
+        "-na",
+        "--no_align",
+        help="Do not align clusters",
+        action="store_true",
+    )
+    alignment.add_argument(
         "-i",
         "--identity",
         help="Minimum alignment sequence identity",
@@ -149,6 +159,7 @@ def main():
         plot=args.plot,
         output=args.output,
         force=args.force,
+        no_align=args.no_align,
         hide_link_headers=args.hide_link_headers,
         hide_alignment_headers=args.hide_aln_headers,
     )


### PR DESCRIPTION
Adds --no_align flag, which allows clinker to visualise clusters without performing alignments