### PR TITLE
Implement parallel computing of alignments

### DIFF
--- a/clinker/align.py
+++ b/clinker/align.py
@@ -28,7 +28,7 @@ from clinker.classes import Serializer, Cluster, Locus, Gene, load_child, load_c
 LOG = logging.getLogger(__name__)
 
 
-def align_clusters(*args, cutoff=0.3, aligner_config=None):
+def align_clusters(*args, cutoff=0.3, aligner_config=None, jobs=None):
     """Convenience function for directly aligning Cluster object/s.
 
     Initialises a Globaligner, adds Cluster/s, then runs alignments
@@ -39,6 +39,7 @@ def align_clusters(*args, cutoff=0.3, aligner_config=None):
         aligner_config (dict): keyword arguments to use when setting
                                up the BioPython.PairwiseAligner object
         cutoff (float): decimal identity cutoff for saving an alignment
+        jobs (int, optional): number of jobs to run alignment in parallel
     Returns:
         aligner (Globaligner): instance of Globaligner class which
                                   contains all cluster alignments
@@ -50,7 +51,7 @@ def align_clusters(*args, cutoff=0.3, aligner_config=None):
     if len(args) == 1:
         LOG.info("Only one cluster given, skipping alignment")
     else:
-        aligner.align_stored_clusters(cutoff)
+        aligner.align_stored_clusters(cutoff, jobs=jobs)
     return aligner
 
 
@@ -171,9 +172,9 @@ class Globaligner(Serializer):
         self.clusters = OrderedDict()
 
         if aligner_config is None:
-            self.aligner_config = aligner_config
+            self.aligner_config = self.aligner_default.copy()
         else:
-            self.aligner_default.copy()
+            self.aligner_config = aligner_config
 
     def to_dict(self):
         """Serialises the Globaligner instance to dict.

--- a/clinker/align.py
+++ b/clinker/align.py
@@ -156,7 +156,7 @@ class Globaligner(Serializer):
 
     aligner_default = {
         "mode": "global",
-        "substitution_matrix": substitution_matrices.load("BLOSUM62"),
+        "substitution_matrix": "BLOSUM62",
         "open_gap_score": -10,
         "extend_gap_score": -0.5,
     }
@@ -174,13 +174,8 @@ class Globaligner(Serializer):
 
         if aligner_config is None:
             self.aligner_config = self.aligner_default.copy()
-            self._matrix_alphabet = self.aligner_config["substitution_matrix"].alphabet
         else:
             self.aligner_config = aligner_config
-            self._matrix_alphabet = aligner_config.get(
-                "substitution_matrix",
-                self.aligner_default["substitution_matrix"]
-            ).alphabet
 
     def to_dict(self):
         """Serialises the Globaligner instance to dict.
@@ -330,14 +325,18 @@ class Globaligner(Serializer):
                     self._genes[gene.uid] = gene
 
     @staticmethod
-    def _align_clusters(config, alphabet, one, two, cutoff=0.3):
+    def _align_clusters(config, one, two, cutoff=0.3):
         """Constructs a cluster alignment using the given configuration."""
         LOG.info("%s vs %s", one.name, two.name)
 
         aligner = Align.PairwiseAligner()
+        matrix = config.pop("substitution_matrix", "BLOSUM62")
+        if matrix not in substitution_matrices.load():
+            LOG.warning("Invalid substitution matrix (%s), defaulting to BLOSUM62", matrix)
+            matrix = "BLOSUM62"
+        aligner.substitution_matrix = substitution_matrices.load(matrix)
         for k, v in config.items():
             setattr(aligner, k, v)
-        aligner.substitution_matrix._alphabet = alphabet
 
         alignment = Alignment(query=one, target=two)
         for locusA, locusB in product(one.loci, two.loci):
@@ -351,13 +350,7 @@ class Globaligner(Serializer):
 
     def align_clusters(self, one, two, cutoff=0.3):
         """Constructs a cluster alignment using aligner config in the Globaligner."""
-        return self._align_clusters(
-            self.aligner_config,
-            self._matrix_alphabet,
-            one,
-            two,
-            cutoff=cutoff
-        )
+        return self._align_clusters(self.aligner_config, one, two, cutoff=cutoff)
 
     def align_stored_clusters(self, cutoff=0.3, jobs=None):
         """Aligns clusters stored in the Globaligner."""
@@ -373,7 +366,6 @@ class Globaligner(Serializer):
             _align_clusters = partial(
                 self._align_clusters,
                 self.aligner_config,
-                self._matrix_alphabet,
                 cutoff=cutoff
             )
             alignments = pool.starmap(_align_clusters, pairs_to_align)
@@ -399,13 +391,6 @@ class Globaligner(Serializer):
                 f"class: { ', '.join(map(repr, sorted(invalid_keys))) }"
             )
         self.aligner_config.update(kwargs)
-        if "substitution_matrix" in kwargs:
-            self._matrix_alphabet = kwargs["substitution_matrix"].alphabet
-
-    # @property
-    # def aligner_settings(self):
-    #     """Returns a printout of the current PairwiseAligner object settings."""
-    #     return str(self.aligner)
 
     def add_alignment(self, alignment, overwrite=False):
         """Adds a new cluster alignment to the Globaligner.

--- a/clinker/main.py
+++ b/clinker/main.py
@@ -38,6 +38,7 @@ def clinker(
     hide_alignment_headers=False,
     use_file_order=False,
     json_indent=None,
+    jobs=None,
 ):
     """Entry point for running the script."""
     LOG.info("Starting clinker")
@@ -55,7 +56,7 @@ def clinker(
 
             LOG.info("Adding clusters to loaded session and aligning")
             globaligner.add_clusters(*clusters)
-            globaligner.align_stored_clusters(cutoff=identity)
+            globaligner.align_stored_clusters(cutoff=identity, jobs=jobs)
             load_session = False
     else:
         # Parse files, generate objects
@@ -68,10 +69,10 @@ def clinker(
             globaligner = align.Globaligner()
             globaligner.add_clusters(*clusters)
         elif len(clusters) == 1:
-            globaligner = align.align_clusters(clusters[0])
+            globaligner = align.align_clusters(clusters[0], jobs=1)
         else:
             LOG.info("Starting cluster alignments")
-            globaligner = align.align_clusters(*clusters, cutoff=identity)
+            globaligner = align.align_clusters(*clusters, cutoff=identity, jobs=jobs)
 
     LOG.info("Generating results summary...")
     summary = globaligner.format(
@@ -144,6 +145,13 @@ def get_parser():
         type=float,
         default=0.3
     )
+    alignment.add_argument(
+        "-j",
+        "--jobs",
+        help="Number of alignments to run in parallel (0 to use the number of CPUs)",
+        type=int,
+        default=0,
+    )
 
     output = parser.add_argument_group("Output options")
     output.add_argument("-s", "--session", help="Path to clinker session")
@@ -203,6 +211,7 @@ def main():
         hide_link_headers=args.hide_link_headers,
         hide_alignment_headers=args.hide_aln_headers,
         use_file_order=args.use_file_order,
+        jobs=args.jobs if args.jobs > 0 else None
     )
 
 


### PR DESCRIPTION
Hi Cameron,

first of all a big thank for this toolkit, building and rendering alignments between our biosynthetic genes clusters have never been that easy, so I felt like I had to give back by contributing a little something :smile:

Since the alignment time greatly increases with each new cluster to align, I added support for parallel computing of the alignment step. To do so, I removed the aligner from `Globaligner`, instead just storing the aligner configuration, and then creating a new one each time `Globaligner.align_clusters` is called. This is actually not affecting performance (the [initialisation code for `Bio.Align.Aligner`](https://github.com/biopython/biopython/blob/fcc6e925a2dd5a4f994ac03e84e25610aebc7c02/Bio/Align/_aligners.c#L1791) is not doing expensive operations).

Because `Bio.Align` is not releasing the GIL, the only way to have true parallelism is to use processes instead of threads. This means the objects must be picklable, which is the case. However, to avoid pickling the entirety of the `Globaligner`, I moved the inner code of the `Globaligner.align_clusters` function into a static method that does not reference the aligner itself; this way, the function can be passed to a process by just pickling the aligner configuration, and not the `Globaligner` itself.

Finally, I added a `-j` / `--jobs` flag to the argument parser, so that the number of processes can be controlled from the CLI. Passing 0 will use the CPU count, passing any positive integers will use that number of processes instead.

On my computer (i7-8550U CPU @ 1.80GHz, with 8 CPUs, 4 cores), aligning the GenBank files in the `examples` folder was about 3.7 times faster:

```
Benchmark #1: python -m clinker.main examples/*.gbk
  Time (mean ± σ):      4.135 s ±  0.207 s    [User: 22.251 s, System: 1.138 s]
  Range (min … max):    3.744 s …  4.490 s    10 runs
 
Benchmark #2: clinker examples/*.gbk
  Time (mean ± σ):     15.210 s ±  0.432 s    [User: 15.261 s, System: 0.707 s]
  Range (min … max):   14.425 s … 15.970 s    10 runs
 
Summary
  'python -m clinker.main examples/*.gbk' ran
    3.68 ± 0.21 times faster than 'clinker examples/*.gbk'
```

Don't hesitate to ping me if you have any question!


