### PR TITLE
Fix gff empty gene

### DIFF
--- a/clinker/align.py
+++ b/clinker/align.py
@@ -341,6 +341,8 @@ class Globaligner(Serializer):
         alignment = Alignment(query=one, target=two)
         for locusA, locusB in product(one.loci, two.loci):
             for geneA, geneB in product(locusA.genes, locusB.genes):
+                if not geneA.translation or not geneB.translation:
+                    continue
                 aln = aligner.align(geneA.translation, geneB.translation)
                 identity, similarity = compute_identity(aln[0])
                 if identity < cutoff:

--- a/clinker/classes.py
+++ b/clinker/classes.py
@@ -86,6 +86,10 @@ def parse_gff(path):
         if not features:
             raise ValueError(f"Found no CDS features in {record.id} [{path}]")
 
+        # Calculate offset based on start of record
+        # sequence-region not zero-indexed, so +1
+        record_start -= 1
+
         previous = None
         for feature in features:
             # Check if this feature is part of the previous one for merging
@@ -98,9 +102,11 @@ def parse_gff(path):
             # Necessary for extracted GFF3 files that still store coordinates
             # relative to the entire region. If no sequence-region directive
             # is found, assumes 1 (i.e. default sequence start).
+            # Note: to_seqfeature automatically zero indexes coordinates, which
+            # does not happen by default in GFFUtils, hence no -1 here
             feature = biopython_integration.to_seqfeature(feature)
             feature.location = FeatureLocation(
-                feature.location.start - record_start - 1,
+                feature.location.start - record_start,
                 feature.location.end - record_start,
                 strand=feature.location.strand
             )
@@ -122,19 +128,18 @@ def parse_gff(path):
         # features), warns user and defaults to CDS start/end.
         genes = []
         for feature in record.features:
-            parent = list(gff.parents(gff[feature.id], featuretype="gene"))
+            parents = [p for p in gff.parents(gff[feature.id], featuretype="gene")]
             start, end = None, None
-            if parent:
-                start = parent[0].start - record_start - 1
-                end = parent[0].end - record_start
+            if parents:
+                start = parents[0].start - record_start - 1
+                end = parents[0].end - record_start
             else:
                 LOG.warning(
                     f"Could not find parent gene of {feature.id}."
                     " Using coding sequence coordinates instead."
                 )
             gene = Gene.from_seqfeature(feature, record, start=start, end=end)
-            if gene:
-                genes.append(gene)
+            genes.append(gene)
 
         locus = Locus(record.id, genes, 0, len(record))
         loci.append(locus)
@@ -440,8 +445,12 @@ class Gene(Serializer):
         }
         sequence = feature.extract(record.seq)
         translation = qualifiers.pop("translation", None) or sequence.translate()
-        if not translation:
-            return
+        print(
+            feature.location.start,
+            feature.location.end,
+            feature.location.strand,
+            start, end, sequence[:10], translation[:10]
+        )
         return cls(
             names=qualifiers,
             label=get_value(qualifiers, tags),

--- a/clinker/classes.py
+++ b/clinker/classes.py
@@ -445,12 +445,6 @@ class Gene(Serializer):
         }
         sequence = feature.extract(record.seq)
         translation = qualifiers.pop("translation", None) or sequence.translate()
-        print(
-            feature.location.start,
-            feature.location.end,
-            feature.location.strand,
-            start, end, sequence[:10], translation[:10]
-        )
         return cls(
             names=qualifiers,
             label=get_value(qualifiers, tags),

--- a/clinker/classes.py
+++ b/clinker/classes.py
@@ -133,7 +133,8 @@ def parse_gff(path):
                     " Using coding sequence coordinates instead."
                 )
             gene = Gene.from_seqfeature(feature, record, start=start, end=end)
-            genes.append(gene)
+            if gene:
+                genes.append(gene)
 
         locus = Locus(record.id, genes, 0, len(record))
         loci.append(locus)


### PR DESCRIPTION
Fixes mismatch between GFFUtils/BioPython coordinates causing Gene objects not to be made during GFF parsing. GFFUtils does not zero index feature locations; `biopython_integration.to_seqfeature()` does, so only have to subtract 1bp when looking at parent genes (which are not converted to `SeqFeature` objects).