### PR TITLE
Group restoration when inst. Globaligner from dict

### DIFF
--- a/clinker/align.py
+++ b/clinker/align.py
@@ -266,6 +266,10 @@ class Globaligner(Serializer):
             ga._alignment_indices[aln.target.uid][aln.query.uid] = aln.uid
             ga._cluster_names[aln.uid] = (aln.query.uid, aln.target.uid)
 
+        for group in d["groups"]:
+            gr = Group.from_dict(group)
+            ga.groups.append(gr)
+
         return ga
 
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "biopython>=1.75",
         "numpy>=1.13.3",
         "scipy>=1.3.3",
-        "disjoint-set>=0.7.1"
+        "disjoint-set>=0.7.1",
         "gffutils",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
Added group restoration when instantiating Globaligner using from_dict method. 
As discussed in #51. 